### PR TITLE
Fix Redux DevTools linter error

### DIFF
--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -15,8 +15,8 @@ export default function configureStore(initialState: any) {
 	const middleware = applyMiddleware(thunk)
 	let composeEnhancers = compose
 
-	if (typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
-		composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+	if (typeof window !== 'undefined' && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
+		composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
 	}
 
 	// Creating our store


### PR DESCRIPTION
This adds (window as any) to Store so that linter can stop complaining about having no REDUX_DEVTOOLS... property